### PR TITLE
Avoid redundant scans for legacy source files

### DIFF
--- a/Version Control.accda.src/modules/clsAdpTable.cls
+++ b/Version Control.accda.src/modules/clsAdpTable.cls
@@ -37,7 +37,6 @@ Implements IDbComponent
 '
 Private Sub IDbComponent_Export(Optional strAlternatePath As String)
     Dim strContent As String
-    ClearFilesByExtension IDbComponent_BaseFolder, "tdf"    ' Legacy extension
     strContent = GetSource
     WriteFile strContent, Nz2(strAlternatePath, IDbComponent_SourceFile)
     VCSIndex.Update Me, IIf(strAlternatePath = vbNullString, eatExport, eatAltExport), GetStringHash(strContent, True)

--- a/Version Control.accda.src/modules/clsDbForm.cls
+++ b/Version Control.accda.src/modules/clsDbForm.cls
@@ -37,7 +37,6 @@ Implements IDbComponent
 '
 Private Sub IDbComponent_Export(Optional strAlternatePath As String)
     Dim strHash As String
-    If Not Options.SavePrintVars Then ClearFilesByExtension IDbComponent_BaseFolder, "json"
     strHash = SaveComponentAsText(acForm, m_Form.Name, Nz2(strAlternatePath, IDbComponent_SourceFile), Me)
     VCSIndex.Update Me, IIf(strAlternatePath = vbNullString, eatExport, eatAltExport), _
         strHash, GetCodeModuleHash(IDbComponent_ComponentType, m_Form.Name)

--- a/Version Control.accda.src/modules/clsDbRelation.cls
+++ b/Version Control.accda.src/modules/clsDbRelation.cls
@@ -51,7 +51,6 @@ End Sub
 '
 Private Sub IDbComponent_Export(Optional strAlternatePath As String)
     Dim strContent As String
-    ClearFilesByExtension IDbComponent_BaseFolder, "txt"    ' Legacy extension
     strContent = GetSource
     WriteFile strContent, Nz2(strAlternatePath, IDbComponent_SourceFile)
     VCSIndex.Update Me, IIf(strAlternatePath = vbNullString, eatExport, eatAltExport), GetStringHash(strContent, True)

--- a/Version Control.accda.src/modules/clsDbReport.cls
+++ b/Version Control.accda.src/modules/clsDbReport.cls
@@ -37,8 +37,6 @@ Implements IDbComponent
 '
 Private Sub IDbComponent_Export(Optional strAlternatePath As String)
     Dim strHash As String
-    ClearFilesByExtension IDbComponent_BaseFolder, "pv" ' Remove legacy files
-    If Not Options.SavePrintVars Then ClearFilesByExtension IDbComponent_BaseFolder, "json"
     strHash = SaveComponentAsText(acReport, m_Report.Name, Nz2(strAlternatePath, IDbComponent_SourceFile), Me)
     VCSIndex.Update Me, IIf(strAlternatePath = vbNullString, eatExport, eatAltExport), _
         strHash, GetCodeModuleHash(IDbComponent_ComponentType, m_Report.Name)

--- a/Version Control.accda.src/modules/clsDbTableDef.cls
+++ b/Version Control.accda.src/modules/clsDbTableDef.cls
@@ -53,11 +53,6 @@ Private Sub IDbComponent_Export(Optional strAlternatePath As String)
         Exit Sub
     End If
 
-    ' Clear any legacy extensions
-    ClearFilesByExtension IDbComponent_BaseFolder, "LNKD"
-    ClearFilesByExtension IDbComponent_BaseFolder, "bas"
-    ClearFilesByExtension IDbComponent_BaseFolder, "tdf"
-
     ' Get the export file name
     strFile = Nz2(strAlternatePath, IDbComponent_SourceFile)
 

--- a/Version Control.accda.src/modules/modImportExport.bas
+++ b/Version Control.accda.src/modules/modImportExport.bas
@@ -102,6 +102,9 @@ Public Sub ExportSource(blnFullExport As Boolean, Optional intFilter As eContain
             Log.Add "Updated VCS (" & Options.GetLoadedVersion & " -> " & GetVCSVersion & ")", , , "blue"
     End Select
 
+    ' Perform any needed upgrades to source files
+    If blnFullExport Then UpgradeSourceFiles
+
     ' Run any custom sub before export
     If Options.RunBeforeExport <> vbNullString Then
         Log.Add "Running " & Options.RunBeforeExport & "..."
@@ -1432,6 +1435,36 @@ Private Sub CheckForLegacyModules()
                 "a simpler, cleaner code base for ongoing development.  :-)", _
                 "NOTE: This message can be disabled in 'Options -> Show Legacy Prompt'.", vbInformation, "Just a Suggestion..."
         End If
+    End If
+
+End Sub
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : UpgradeSourceFiles
+' Author    : Adam Waller
+' Date      : 8/7/2024
+' Purpose   : Removes any legacy file formats used by earlier versions of this add-in.
+'---------------------------------------------------------------------------------------
+'
+Private Sub UpgradeSourceFiles()
+
+    Dim strBase As String
+
+    strBase = Options.GetExportFolder
+
+    ' Remove legacy files by extension
+    ClearFilesByExtension strBase & "sqltables", "tdf"
+    ClearFilesByExtension strBase & "relations", "txt"      ' Relationships (pre-json)
+    ClearFilesByExtension strBase & "report", "pv"          ' Print vars text file (pre-json)
+    ClearFilesByExtension strBase & "tbldefs", "LNKD"       ' Formerly used for linked tables
+    ClearFilesByExtension strBase & "tbldefs", "bas"        ' Moved to XML format
+    ClearFilesByExtension strBase & "tbldefs", "tdf"
+
+    ' Clear any print settings files if not using this option
+    If Not Options.SavePrintVars Then
+        ClearFilesByExtension "forms", "json"
+        ClearFilesByExtension "reports", "json"
     End If
 
 End Sub


### PR DESCRIPTION
 These calls only need to be run during a full export. Definitely not repeated for each object exported. We may do some further cleanup later as some of these legacy files are far enough removed from the current version that the checks are probably no longer needed. See #527