### PR TITLE
Install compiled add-in (option "Create compiled version" in frmVCSInstall)

### DIFF
--- a/Version Control.accda.src/forms/frmVCSInstall.bas
+++ b/Version Control.accda.src/forms/frmVCSInstall.bas
@@ -923,19 +923,19 @@ Begin Form
                                     TabStop = NotDefault
                                     OverlapFlags =215
                                     Left =660
-                                    Top =2670
+                                    Top =2576
                                     Name ="chkOpenAfterInstall"
                                     DefaultValue ="False"
 
                                     LayoutCachedLeft =660
-                                    LayoutCachedTop =2670
+                                    LayoutCachedTop =2576
                                     LayoutCachedWidth =920
-                                    LayoutCachedHeight =2910
+                                    LayoutCachedHeight =2816
                                     Begin
                                         Begin Label
                                             OverlapFlags =215
                                             Left =945
-                                            Top =2640
+                                            Top =2546
                                             Width =2595
                                             Height =465
                                             FontSize =10
@@ -943,9 +943,9 @@ Begin Form
                                             Name ="Label36"
                                             Caption ="Open add-in after installing to trust the add-in file"
                                             LayoutCachedLeft =945
-                                            LayoutCachedTop =2640
+                                            LayoutCachedTop =2546
                                             LayoutCachedWidth =3540
-                                            LayoutCachedHeight =3105
+                                            LayoutCachedHeight =3011
                                             ForeThemeColorIndex =-1
                                             ForeTint =100.0
                                         End
@@ -1094,6 +1094,39 @@ Begin Form
                                     BackColor =15130848
                                     BackThemeColorIndex =-1
                                     BackTint =100.0
+                                End
+                                Begin CheckBox
+                                    TabStop = NotDefault
+                                    OverlapFlags =215
+                                    Left =660
+                                    Top =3064
+                                    TabIndex =4
+                                    Name ="chkCreateCompiledVersion"
+                                    DefaultValue ="False"
+
+                                    LayoutCachedLeft =660
+                                    LayoutCachedTop =3064
+                                    LayoutCachedWidth =920
+                                    LayoutCachedHeight =3304
+                                    Begin
+                                        Begin Label
+                                            OverlapFlags =215
+                                            Left =945
+                                            Top =3034
+                                            Width =2595
+                                            Height =285
+                                            FontSize =10
+                                            ForeColor =5324600
+                                            Name ="Label68"
+                                            Caption ="Create compiled version"
+                                            LayoutCachedLeft =945
+                                            LayoutCachedTop =3034
+                                            LayoutCachedWidth =3540
+                                            LayoutCachedHeight =3319
+                                            ForeThemeColorIndex =-1
+                                            ForeTint =100.0
+                                        End
+                                    End
                                 End
                             End
                         End

--- a/Version Control.accda.src/forms/frmVCSInstall.cls
+++ b/Version Control.accda.src/forms/frmVCSInstall.cls
@@ -75,7 +75,7 @@ Private Sub cmdInstall_Click()
     End If
 
     ' Run the installer
-    modInstall.InstallVCSAddin chkAddTrustedLocation, chkUseRibbon, chkOpenAfterInstall, txtInstallFolder
+    modInstall.InstallVCSAddin chkAddTrustedLocation, chkUseRibbon, chkOpenAfterInstall, txtInstallFolder, chkCreateCompiledVersion
     DoCmd.Hourglass False
 
 End Sub

--- a/Version Control.accda.src/modules/modInstall.bas
+++ b/Version Control.accda.src/modules/modInstall.bas
@@ -86,7 +86,8 @@ End Function
 '           : Returns true if successful.
 '---------------------------------------------------------------------------------------
 '
-Public Sub InstallVCSAddin(blnTrustFolder As Boolean, blnUseRibbon As Boolean, blnOpenAfterInstall As Boolean, strInstallFolder As String)
+Public Sub InstallVCSAddin(blnTrustFolder As Boolean, blnUseRibbon As Boolean, blnOpenAfterInstall As Boolean, strInstallFolder As String, _
+            Optional ByVal blnCreateCompiledVersion As Boolean = False)
 
     Const OPEN_MODE_OPTION As String = "Default Open Mode for Databases"
 
@@ -144,7 +145,7 @@ Public Sub InstallVCSAddin(blnTrustFolder As Boolean, blnUseRibbon As Boolean, b
     If this.blnTrustAddInFolder Then VerifyTrustedLocation
 
     ' Copy the add-in file
-    If Not UpdateAddInFile Then Exit Sub
+    If Not UpdateAddInFile(blnCreateCompiledVersion) Then Exit Sub
 
     ' Install the ribbon
     If this.blnUseRibbonAddIn Then
@@ -262,7 +263,7 @@ End Sub
 ' Purpose   : Update the add-in database file. Return true if successful.
 '---------------------------------------------------------------------------------------
 '
-Private Function UpdateAddInFile() As Boolean
+Private Function UpdateAddInFile(ByVal blnCreateCompiledVersion As Boolean) As Boolean
 
     ' Make sure the destination folder exists
     VerifyPath GetAddInFileName
@@ -271,7 +272,13 @@ Private Function UpdateAddInFile() As Boolean
     LogUnhandledErrors
     On Error Resume Next
     If FSO.FileExists(GetAddInFileName) Then DeleteFile GetAddInFileName, True
-    FSO.CopyFile CodeProject.FullName, GetAddInFileName, True
+
+    If blnCreateCompiledVersion Then
+        CreateAccde CodeProject.FullName, GetAddInFileName
+    Else
+        FSO.CopyFile CodeProject.FullName, GetAddInFileName, True
+    End If
+
     If Err Then
         MsgBox2 "Unable to Update File", _
             "Encountered error " & Err.Number & ": " & Err.Description & " when copying file.", _
@@ -285,6 +292,24 @@ Private Function UpdateAddInFile() As Boolean
     End If
 
 End Function
+
+Private Sub CreateAccde(ByVal SourceFilePath As String, ByVal DestFilePath As String)
+
+    Dim FileToCompile As String
+    Dim AccessApp As Access.Application
+
+    FileToCompile = DestFilePath & ".accdb"
+
+    FSO.CopyFile SourceFilePath, FileToCompile, True
+
+    Set AccessApp = New Access.Application
+    AccessApp.Visible = True
+    'create accde
+    AccessApp.SysCmd 603, (FileToCompile), (DestFilePath)
+
+    FSO.DeleteFile FileToCompile, True
+
+End Sub
 
 
 '---------------------------------------------------------------------------------------
@@ -510,7 +535,7 @@ Public Sub Deploy(Optional ReleaseType As eReleaseType = Same_Version)
     CopyFileToZip CodeProject.FullName, strBinaryFile
 
     ' Deploy latest version on this machine
-    If Not UpdateAddInFile Then Exit Sub
+    If Not UpdateAddInFile(False) Then Exit Sub
 
     ' Use the newly installed add-in to Export the project to version control.
     modAPI.HandleRibbonCommand "btnExport"


### PR DESCRIPTION
### Form Layout Adjustments:
* Adjusted the `Top` and `LayoutCachedTop` properties of various elements in the `frmVCSInstall` form to improve layout alignment.
* Added a new `CheckBox` named `chkCreateCompiledVersion` to the `frmVCSInstall` form, including associated label and layout properties.

### Installation Process Enhancements:
* Updated the `cmdInstall_Click` subroutine to include the new `chkCreateCompiledVersion` checkbox as a parameter in the `InstallVCSAddin` call.
* Modified the `InstallVCSAddin` subroutine to accept an optional `blnCreateCompiledVersion` parameter, defaulting to `False`.
* Updated the `UpdateAddInFile` function to accept the `blnCreateCompiledVersion` parameter and conditionally create a compiled version of the add-in.

### New Functionality:
* Added a new `CreateAccde` subroutine to handle the creation of a compiled version (`.accde`) of the add-in file.

These changes collectively enhance the installation process by providing an option to create a compiled version of the add-in, improving form layout, and ensuring the new functionality is integrated seamlessly.