### PR TITLE
Avoid rename VBProject.Name

### DIFF
--- a/Version Control.accda.src/modules/modDatabase.bas
+++ b/Version Control.accda.src/modules/modDatabase.bas
@@ -554,13 +554,16 @@ Public Sub RunSubInCurrentProject(strSubName As String)
 
     ' Check for add-in project name
     If StrComp(CurrentVBProject.Name, GetAddInProject.Name, vbTextCompare) = 0 Then
-        ' Temporarily rename the add-in project so the sub runs in the current project.
-        GetAddInProject.Name = "MSAccessVCS-Lib"
-        Application.Run strCmd
-        GetAddInProject.Name = PROJECT_NAME
-    Else
-        Application.Run strCmd
+        ' Temporarily rename the add-in project so the sub runs in the current project ... Not required: call with full name
+        Dim VbProjectFilenameWithoutFileExt As String
+        Const AddInFileExtension As String = ".accda"
+        With CurrentVBProject
+            VbProjectFilenameWithoutFileExt = Left(.FileName, Len(.FileName) - Len(AddInFileExtension))
+            strCmd = Replace(strCmd, "[" & .Name & "]", VbProjectFilenameWithoutFileExt)
+        End With
     End If
+
+    Application.Run strCmd
 
 End Sub
 


### PR DESCRIPTION
Use full name (full file name without file extension) for Application.Run