### PR TITLE
run sub before export option: Allow call an add-in procedure

### DIFF
--- a/Testing/Tests/Testing/TestHelperCallbackBridge.cls
+++ b/Testing/Tests/Testing/TestHelperCallbackBridge.cls
@@ -1,0 +1,21 @@
+VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = "TestHelperCallbackBridge"
+Attribute VB_GlobalNameSpace = False
+Attribute VB_Creatable = False
+Attribute VB_PredeclaredId = False
+Attribute VB_Exposed = False
+Option Compare Database
+Option Explicit
+
+' AccUnit:TestRelated
+
+Public FunctionReturnValue As Variant
+Public CalledProcedure As String
+
+Public Sub CommitProcedureCall(ByVal ProcedureName As String)
+   CalledProcedure = ProcedureName
+End Sub
+

--- a/Testing/Tests/Testing/clsVersionControlRunBeforeExportTests.cls
+++ b/Testing/Tests/Testing/clsVersionControlRunBeforeExportTests.cls
@@ -1,0 +1,162 @@
+VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = "clsVersionControlRunBeforeExportTests"
+Attribute VB_GlobalNameSpace = False
+Attribute VB_Creatable = False
+Attribute VB_PredeclaredId = False
+Attribute VB_Exposed = False
+Option Compare Text
+Option Explicit
+
+'AccUnit:TestClass
+
+Private m_VCS As Object
+Private m_TestBridge As TestHelperCallbackBridge
+
+'--------------------------------------------------------------------
+' Test Preparation / Cleanup
+'--------------------------------------------------------------------
+Public Sub Setup()
+
+    Set m_VCS = GetVCS
+    m_VCS.SilentMode = True
+    Set m_TestBridge = New TestHelperCallbackBridge
+    modTestHelper_RunBeforeTestProc.SetTestBridge m_TestBridge
+    
+End Sub
+
+Public Sub TearDown()
+
+    If Err.Number <> 0 Then 'remove error: VCS checks err object!
+       Err.Clear
+    End If
+    
+    DoCmd.Close acForm, "frmVCSMain"
+    
+    modTestHelper_RunBeforeTestProc.SetTestBridge Nothing
+    Set m_TestBridge = Nothing
+    
+    m_VCS.Options.RunBeforeExport = vbNullString
+    m_VCS.Options.SaveOptionsForProject
+    
+    Set m_VCS = Nothing
+    
+End Sub
+
+'--------------------------------------------------------------------
+' Tests
+'--------------------------------------------------------------------
+
+Public Sub TestRunBeforeExport_CallSub_CheckCall()
+
+    Const ProcedureToStart As String = "RunBeforeExportTestFunction1"
+    Dim VcsErrorLevel As Long
+    
+    m_VCS.Options.RunBeforeExport = ProcedureToStart
+    m_VCS.Options.SaveOptionsForProject
+    VcsErrorLevel = m_VCS.ExportVBA
+    
+    Assert.That m_TestBridge.CalledProcedure, Iz.EqualTo(ProcedureToStart)
+
+End Sub
+
+Public Sub TestRunBeforeExport_CallFunction_CheckCallAndErrorLevel()
+
+    Const ProcedureToStart As String = "RunBeforeExportTestFunction2"
+    Dim VcsErrorLevel As Long
+    
+    m_TestBridge.FunctionReturnValue = True
+    
+    m_VCS.Options.RunBeforeExport = ProcedureToStart
+    m_VCS.Options.SaveOptionsForProject
+    VcsErrorLevel = m_VCS.ExportVBA
+    
+    Assert.That m_TestBridge.CalledProcedure, Iz.EqualTo(ProcedureToStart)
+
+End Sub
+
+'AccUnit:Row(True, 0).Name = "True"
+'AccUnit:Row(False, 5).Name = "False"
+Public Sub TestRunBeforeExport_CallBooleanFunction_CheckCallAndErrorLevelFailed(ByVal FunctionReturnValue As Boolean, ByVal ExpectedErrorLevel As Long)
+
+    Const ProcedureToStart As String = "RunBeforeExportTestFunction2"
+    Dim VcsErrorLevel As Long
+    
+    m_TestBridge.FunctionReturnValue = FunctionReturnValue
+    
+    m_VCS.Options.RunBeforeExport = ProcedureToStart
+    m_VCS.Options.SaveOptionsForProject
+    VcsErrorLevel = m_VCS.ExportVBA
+    
+    Assert.That m_TestBridge.CalledProcedure, Iz.EqualTo(ProcedureToStart)
+    Assert.That VcsErrorLevel, Iz.EqualTo(ExpectedErrorLevel)
+
+End Sub
+
+'AccUnit:Row("Log: ...", 1, False).Name = "Log"
+'AccUnit:Row("Info: ...", 2, False).Name = "Info"
+'AccUnit:Row("Success: ...", 2, False).Name = "Success"
+'AccUnit:Row("Note: ...", 2, False).Name = "Note"
+'AccUnit:Row("Warning: ...", 3, True).Name = "Warning"
+'AccUnit:Row("Alert: ...", 3, True).Name = "Alert"
+'AccUnit:Row("Failed: ...", 3, True).Name = "Failed"
+'AccUnit:Row("Error: ...", 4, true).Name = "Error"
+'AccUnit:Row("Critical: ...", 5, true).Name = "Critical"
+Public Sub TestRunBeforeExport_CallStringFunction_CheckCallAndErrorLevelFailed( _
+                            ByVal FunctionReturnValue As String, _
+                            ByVal ExpectedErrorLevel As Long, _
+                            ByVal ExpectedVcsMainFormIsOpen As Boolean)
+
+    Const ProcedureToStart As String = "RunBeforeExportTestFunction3"
+    Dim VcsErrorLevel As Long
+    
+    m_TestBridge.FunctionReturnValue = FunctionReturnValue
+    
+    m_VCS.Options.RunBeforeExport = ProcedureToStart
+    m_VCS.Options.SaveOptionsForProject
+    VcsErrorLevel = m_VCS.ExportVBA
+'Stop
+With ErrorTrappingObserver
+    .SetErrorTrapping 2
+    Assert.That m_TestBridge.CalledProcedure, Iz.EqualTo(ProcedureToStart)
+    Assert.That VcsErrorLevel, Iz.EqualTo(ExpectedErrorLevel)
+    Assert.That VcsMainFormIsOpen, Iz.EqualTo(ExpectedVcsMainFormIsOpen)
+End With
+
+End Sub
+
+'--------------------------------------------------------------------
+' Test helper procedures
+'--------------------------------------------------------------------
+Private Function GetVCS() As Object
+   Set GetVCS = RunOjectAddInProcedure("VCS")
+End Function
+
+Private Function GetLog() As Object
+   Set GetLog = RunOjectAddInProcedure("Log")
+End Function
+
+Private Function RunOjectAddInProcedure(ByVal ProcedureName As String) As Object
+   Set RunOjectAddInProcedure = Application.Run(GetMsAccessVcsPath & "\Version Control." & ProcedureName)
+End Function
+
+Private Function GetMsAccessVcsPath() As String
+   GetMsAccessVcsPath = Environ("Appdata") & "\MsAccessVCS"
+End Function
+
+Private Function VcsMainFormIsOpen() As Boolean
+    
+    Dim frm As Form
+    
+    For Each frm In Forms
+        If frm.Name = "frmVCSMain" Then
+            VcsMainFormIsOpen = True
+            Exit Function
+        End If
+    Next
+    
+End Function
+
+

--- a/Testing/Tests/Testing/modTestHelper_RunBeforeTestProc.bas
+++ b/Testing/Tests/Testing/modTestHelper_RunBeforeTestProc.bas
@@ -1,0 +1,37 @@
+Attribute VB_Name = "modTestHelper_RunBeforeTestProc"
+Option Compare Database
+Option Explicit
+
+' AccUnit:TestRelated
+
+Private m_TestBridge As TestHelperCallbackBridge
+
+Public Sub SetTestBridge(ByVal NewRef As TestHelperCallbackBridge)
+   Set m_TestBridge = NewRef
+End Sub
+
+Public Sub RunBeforeExportTestFunction1()
+   If m_TestBridge Is Nothing Then
+      Debug.Print "RunBeforeExportTestFunction1 called"
+   Else
+      m_TestBridge.CommitProcedureCall "RunBeforeExportTestFunction1"
+   End If
+End Sub
+
+Public Function RunBeforeExportTestFunction2() As Boolean
+   If m_TestBridge Is Nothing Then
+      Debug.Print "RunBeforeExportTestFunction2 called"
+   Else
+      m_TestBridge.CommitProcedureCall "RunBeforeExportTestFunction2"
+      RunBeforeExportTestFunction2 = CBool(m_TestBridge.FunctionReturnValue)
+   End If
+End Function
+
+Public Function RunBeforeExportTestFunction3() As String
+   If m_TestBridge Is Nothing Then
+      Debug.Print "RunBeforeExportTestFunction3 called"
+   Else
+      m_TestBridge.CommitProcedureCall "RunBeforeExportTestFunction3"
+      RunBeforeExportTestFunction3 = m_TestBridge.FunctionReturnValue
+   End If
+End Function

--- a/Version Control.accda.src/forms/frmVCSMain.cls
+++ b/Version Control.accda.src/forms/frmVCSMain.cls
@@ -426,13 +426,17 @@ End Sub
 '           :  completion and close.)
 '---------------------------------------------------------------------------------------
 '
-Public Sub AutoClose()
+Public Sub AutoClose(Optional CloseTimerInterval As Long = 2000)
     'The procedure may be called when the form has been closed.
     'In this case, a VBA error may occur, so we check if the
     'form is loaded before setting the property. We do not use
     'the Me.Name because that would be also an error.
     If IsLoaded(acForm, "frmVCSMain", False) Then
-        Me.TimerInterval = 2000
+        If CloseTimerInterval = 0 Then
+            Call Form_Timer
+        Else
+            Me.TimerInterval = CloseTimerInterval
+        End If
     End If
 End Sub
 

--- a/Version Control.accda.src/modules/clsLog.cls
+++ b/Version Control.accda.src/modules/clsLog.cls
@@ -171,11 +171,37 @@ Public Sub Error(eLevel As eErrorLevel, strDescription As String, Optional strSo
 
     Dim strPrefix As String
     Dim strDisplay As String
+    Dim bolLogToFile As Boolean
+    Dim bolDisplay As Boolean
+    Dim MsgBoxStyle As VbMsgBoxStyle
+    Dim MsgBoxPrefix As String
+    Dim strColor As String
+
+    bolDisplay = (eLevel > eelWarning)
+    strColor = "red"
 
     Select Case eLevel
-        Case eelWarning:    strPrefix = "WARNING: "
-        Case eelError:      strPrefix = "ERROR: "
-        Case eelCritical:   strPrefix = "CRITICAL: "
+        Case eErrorLevel.eelError
+            strPrefix = "ERROR: "
+            MsgBoxPrefix = "Error"
+            MsgBoxStyle = vbExclamation
+        Case eErrorLevel.eelWarning, eErrorLevel.eelAlert
+            strPrefix = "WARNING: "
+            MsgBoxPrefix = "Warning"
+            MsgBoxStyle = vbInformation
+        Case eErrorLevel.eelCritical
+            strPrefix = "CRITICAL: "
+            MsgBoxPrefix = "Critical"
+            MsgBoxStyle = vbCritical
+        Case eErrorLevel.eelInfo
+            strPrefix = "INFO: "
+            MsgBoxPrefix = "Info"
+            MsgBoxStyle = vbInformation
+            strColor = "blue"
+        Case Else
+            strPrefix = "INFO: "
+            MsgBoxPrefix = "Info"
+            MsgBoxStyle = vbInformation
     End Select
 
     ' Build the error message string.
@@ -189,31 +215,33 @@ Public Sub Error(eLevel As eErrorLevel, strDescription As String, Optional strSo
         End If
 
         ' Log all errors, and display on the output screen anything higher than a warning
-        Me.Add vbNullString, (eLevel > eelWarning)
-        Me.Spacer (eLevel > eelWarning)
-        Me.Add strDisplay, (eLevel > eelWarning), , "red"
+        Me.Add vbNullString, bolDisplay
+        Me.Spacer bolDisplay
+        Me.Add strDisplay, bolDisplay, , strColor
 
         ' Log the additional error and source details to the log file
         If Err Then .Add "Error ", Err.Number, ": ", Err.Description, " "
         If strSource <> vbNullString Then .Add "Source: ", strSource
         Me.Add .GetStr, False
-        Me.Spacer (eLevel > eelWarning)
+        Me.Spacer bolDisplay
         Me.Flush ' Force a screen update.
         ' See if we are actively logging an operation
         If Log.Active Then
             ' Show message box for fatal error.
             If eLevel = eelCritical Then
-                MsgBox2 "Unable to Continue", .GetStr, _
-                    "Please review the log file for additional details.", vbCritical
+                If InteractionMode = eimSilent Then
+                    Me.Add "Unable to Continue", True, , "red", True
+                    Me.Add "Please review the log file for additional details.", True
+                Else
+                    MsgBox2 "Unable to Continue", .GetStr, _
+                            "Please review the log file for additional details.", vbCritical
+                End If
             End If
         Else
             ' Show message on any error level when we are not logging to a file.
-            Select Case eLevel
-                Case eelNoError:    ' Do nothing
-                Case eelWarning:    MsgBox2 "Warning", strDisplay, .GetStr, vbInformation
-                Case eelError:      MsgBox2 "Error", strDisplay, .GetStr, vbExclamation
-                Case eelCritical:   MsgBox2 "Critical", strDisplay, .GetStr, vbCritical
-            End Select
+            If eLevel > 0 Then
+                MsgBox2 MsgBoxPrefix, strDisplay, .GetStr, MsgBoxStyle
+            End If
         End If
     End With
 

--- a/Version Control.accda.src/modules/clsVersionControl.cls
+++ b/Version Control.accda.src/modules/clsVersionControl.cls
@@ -58,10 +58,10 @@ End Sub
 ' Purpose   : Export the source code for the current database
 '---------------------------------------------------------------------------------------
 '
-Public Sub Export()
-    If HasFormOpen Then Exit Sub
-    RunExport ecfAllObjects
-End Sub
+Public Function Export() As eErrorLevel
+    If HasFormOpen Then Exit Function
+    Export = RunExport(ecfAllObjects)
+End Function
 
 
 '---------------------------------------------------------------------------------------
@@ -71,10 +71,10 @@ End Sub
 ' Purpose   : Export just the VBA related components
 '---------------------------------------------------------------------------------------
 '
-Public Sub ExportVBA()
-    If HasFormOpen Then Exit Sub
-    RunExport ecfVBAItems
-End Sub
+Public Function ExportVBA() As eErrorLevel
+    If HasFormOpen Then Exit Function
+    ExportVBA = RunExport(ecfVBAItems)
+End Function
 
 
 '---------------------------------------------------------------------------------------
@@ -84,23 +84,24 @@ End Sub
 ' Purpose   : Export the selected object
 '---------------------------------------------------------------------------------------
 '
-Public Sub ExportSelected()
+Public Function ExportSelected() As eErrorLevel
 
     Dim objSelected As AccessObject
 
-    If HasFormOpen Then Exit Sub
+    If HasFormOpen Then Exit Function
 
     Set objSelected = GetSelectedNavPaneObject
     If objSelected Is Nothing Then
+        ExportSelected = eelCritical
         MsgBox2 "Please Select an Object First", _
             "Select a single object in the Navigation Pane to export.", _
             "(This item must have the keyboard focus.)", vbInformation
     Else
         ' Export the item
-        RunExport , objSelected
+        ExportSelected = RunExport(, objSelected)
     End If
 
-End Sub
+End Function
 
 
 '---------------------------------------------------------------------------------------
@@ -110,7 +111,10 @@ End Sub
 ' Purpose   : Handle different kinds of exports based on filter
 '---------------------------------------------------------------------------------------
 '
-Private Sub RunExport(Optional intFilter As eContainerFilter = ecfAllObjects, Optional objItem As AccessObject)
+Private Function RunExport(Optional intFilter As eContainerFilter = ecfAllObjects, Optional objItem As AccessObject) As eErrorLevel
+
+    Dim ExportErrorLevel As eErrorLevel
+
     DoCmd.OpenForm "frmVCSMain", , , , , acHidden
     With Form_frmVCSMain
         If objItem Is Nothing Then
@@ -120,9 +124,19 @@ Private Sub RunExport(Optional intFilter As eContainerFilter = ecfAllObjects, Op
         End If
         .Visible = True
         .cmdExport_Click
-        If Log.ErrorLevel < eelError Then .AutoClose
+        ExportErrorLevel = Log.ErrorLevel
+        If ExportErrorLevel <= eelInfo Then
+            If InteractionMode = eimSilent Then
+                .AutoClose 0
+            Else
+                .AutoClose
+            End If
+        End If
     End With
-End Sub
+
+    RunExport = ExportErrorLevel
+
+End Function
 
 
 '---------------------------------------------------------------------------------------
@@ -566,7 +580,7 @@ Private Sub SaveState()
 
     ' Error trapping setting. (We need this to "Break in Class Modules" for this add-in)
     strValue = Application.GetOption("Error Trapping")
-    If strValue <> "1" Then
+    If strValue < "1" Then  ' 2 should also work
         PreserveSetting "Error Trapping", strValue
         Application.SetOption "Error Trapping", 1
     End If
@@ -666,3 +680,36 @@ Private Function HasFormOpen(Optional blnWarnUser As Boolean = True) As Boolean
     Next
 
 End Function
+
+
+'---------------------------------------------------------------------------------------
+' Property  : SilentMode
+' Purpose   : Activate InteractionMode = eimSilent inside VCS
+'---------------------------------------------------------------------------------------
+'
+Public Property Get SilentMode() As Boolean
+    SilentMode = (InteractionMode = eimSilent)
+End Property
+
+Public Property Let SilentMode(ByVal RunInSilentMode As Boolean)
+    If RunInSilentMode Then
+        SetInteractionMode eimSilent
+    Else
+        SetInteractionMode eimNormal
+    End If
+End Property
+
+'---------------------------------------------------------------------------------------
+' Procedure : AddLog
+' Purpose   : Save Log from external (using API)
+'---------------------------------------------------------------------------------------
+'
+Public Sub AddLog(strText As String, Optional blnPrint As Boolean = True, _
+         Optional blnNextOutputOnNewLine As Boolean = True, _
+         Optional strColor As String = vbNullString, _
+         Optional blnBold As Boolean = False, _
+         Optional blnItalic As Boolean = False)
+
+   Log.Add strText, blnPrint, blnNextOutputOnNewLine, strColor, blnBold, blnItalic
+
+End Sub

--- a/Version Control.accda.src/modules/modAPI.bas
+++ b/Version Control.accda.src/modules/modAPI.bas
@@ -36,6 +36,17 @@ Public Enum eSanitizeLevel
     [_Last]         ' Placeholder for the end of the list.
 End Enum
 
+' Error levels used for logging and monitoring the status
+' of the current operation.
+Public Enum eErrorLevel
+    eelNoError = 0
+    eelWarning = 1   ' Logged to file  ... rename to eelLogOnly?
+    eelInfo = 2      ' Displayed and logged, show Note (not red) - allow AutoClose
+    eelAlert = 3     ' Displayed and logged, show Warning not Error
+    eelError = 4     ' Displayed and logged
+    eelCritical = 5  ' Cancel operation
+End Enum
+
 
 '---------------------------------------------------------------------------------------
 ' Procedure : HandleRibbonCommand

--- a/Version Control.accda.src/modules/modConstants.bas
+++ b/Version Control.accda.src/modules/modConstants.bas
@@ -102,15 +102,6 @@ Public Enum eRepositoryApp
     eraTortoiseGit = 4
 End Enum
 
-' Error levels used for logging and monitoring the status
-' of the current operation.
-Public Enum eErrorLevel
-    eelNoError
-    eelWarning      ' Logged to file
-    eelError        ' Displayed and logged
-    eelCritical     ' Cancel operation
-End Enum
-
 ' Compare mode for cloning dictionary object
 ' See CloneDictionary function
 Public Enum eCompareMethod2


### PR DESCRIPTION
This pull request includes significant changes to the testing and logging functionalities in the codebase. The changes introduce new test classes, modify existing logging mechanisms, and update export functions to return error levels.

### Testing Enhancements:
* [`Testing/Tests/Testing/TestHelperCallbackBridge.cls`](diffhunk://#diff-daa2c018a4b63b89bf17eedad57bcdf2cb70048e489cf14dbf904eb4817054cfR1-R21): Added a new class `TestHelperCallbackBridge` to handle procedure calls and return values for testing purposes.
* [`Testing/Tests/Testing/clsVersionControlRunBeforeExportTests.cls`](diffhunk://#diff-194fe7b85ea52b81e16ae82fadbdd213594b5607001c66ac3afe47e75d912159R1-R162): Introduced a new test class `clsVersionControlRunBeforeExportTests` with multiple test methods to validate the `RunBeforeExport` functionality.
* [`Testing/Tests/Testing/modTestHelper_RunBeforeTestProc.bas`](diffhunk://#diff-f9f15801dbc02dde6c9ea7b04d130c256eac68ab65d7f7f390f13815bb2b093aR1-R37): Added a new module `modTestHelper_RunBeforeTestProc` to manage test bridge setting and procedure calls for the `RunBeforeExport` tests.

### Logging Improvements:
* [`Version Control.accda.src/modules/clsLog.cls`](diffhunk://#diff-3e1a953ed250ba289d7702a4ee8cf51fa8e971aa9af947d4f12436ea95a6c5a8R174-R204): Enhanced the `Error` method to include additional logging details, such as color coding and message box styles, based on error levels. [[1]](diffhunk://#diff-3e1a953ed250ba289d7702a4ee8cf51fa8e971aa9af947d4f12436ea95a6c5a8R174-R204) [[2]](diffhunk://#diff-3e1a953ed250ba289d7702a4ee8cf51fa8e971aa9af947d4f12436ea95a6c5a8L192-R244)

### Export Function Updates:
* [`Version Control.accda.src/modules/clsVersionControl.cls`](diffhunk://#diff-41e59cb58102c060b98a034d667b2d66cacc5704ce94e229b3715973c3ebd224L61-R64): Modified export functions (`Export`, `ExportVBA`, `ExportSelected`) to return `eErrorLevel` instead of being `Sub` procedures. [[1]](diffhunk://#diff-41e59cb58102c060b98a034d667b2d66cacc5704ce94e229b3715973c3ebd224L61-R64) [[2]](diffhunk://#diff-41e59cb58102c060b98a034d667b2d66cacc5704ce94e229b3715973c3ebd224L74-R77) [[3]](diffhunk://#diff-41e59cb58102c060b98a034d667b2d66cacc5704ce94e229b3715973c3ebd224L87-R104)
* [`Version Control.accda.src/modules/modDatabase.bas`](diffhunk://#diff-7b5b10bb54dff0ce41108f5f8fc65dfdee28c4b87b84d92d66241eebf5da2c39L559-R627): Added a new method `ExecuteLoggedApplicationRun` to handle logged procedure execution and error reporting.

### Enum and Helper Additions:
* [`Version Control.accda.src/modules/modAPI.bas`](diffhunk://#diff-36519cd13951cbf0379e579ff4f15a3b1c4ef6cec82e996ab2a6ddeae1dcd000R39-R49): Introduced a new `eErrorLevel` enum to standardize error levels across the application.
* [`Version Control.accda.src/modules/modConstants.bas`](diffhunk://#diff-b652ef2cdb5261b753af75d8aa3fbda7544a840151f29c979f1ae49a4a37be38L105-L113): Removed the old `eErrorLevel` enum definition to avoid redundancy.

These changes collectively improve the robustness of the testing framework, enhance logging clarity, and ensure consistent error handling during export operations.